### PR TITLE
Fix return value ambiguities

### DIFF
--- a/src/main/java/io/rathr/audrey/instrumentation/Audrey.java
+++ b/src/main/java/io/rathr/audrey/instrumentation/Audrey.java
@@ -14,7 +14,6 @@ import io.rathr.audrey.storage.*;
 import org.graalvm.polyglot.Engine;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
@@ -164,9 +163,13 @@ public class Audrey implements Closeable {
             return enteringRoot;
         }
 
-        public void enter(final String rootNodeId) {
+        public void enterRoot(final String rootNodeId) {
             this.rootNodeId = rootNodeId;
             this.enteringRoot = true;
+        }
+
+        public void exitRoot() {
+            this.rootNodeId = "<Unknown>";
         }
 
         public void setEnteringRoot(final boolean flag) {
@@ -266,7 +269,7 @@ public class Audrey implements Closeable {
             // extracted from the following statement in the root body can be marked as argument samples.
             if (context.hasTag(ROOT_TAG)) {
                 final String rootNodeId = extractRootName(instrumentedNode);
-                instrumentationContext.enter(rootNodeId);
+                instrumentationContext.enterRoot(rootNodeId);
                 return;
             }
 
@@ -363,6 +366,7 @@ public class Audrey implements Closeable {
             );
 
             storage.add(sample);
+            instrumentationContext.exitRoot();
         }
     }
 }

--- a/src/main/java/io/rathr/audrey/instrumentation/Audrey.java
+++ b/src/main/java/io/rathr/audrey/instrumentation/Audrey.java
@@ -15,6 +15,7 @@ import org.graalvm.polyglot.Engine;
 
 import java.io.Closeable;
 import java.util.Arrays;
+import java.util.Stack;
 import java.util.stream.IntStream;
 
 import static com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -152,11 +153,17 @@ public class Audrey implements Closeable {
     }
 
     private static final class InstrumentationContext {
-        private String rootNodeId = "<Unknown>";
+        private final Stack<String> rootNodeIds;
+
+        // I.e. for our purposes: we are instrumenting the first statement in a root node.
         private boolean enteringRoot = false;
 
+        public InstrumentationContext() {
+            this.rootNodeIds = new Stack<>();
+        }
+
         public String getRootNodeId() {
-            return rootNodeId;
+            return rootNodeIds.peek();
         }
 
         public boolean isEnteringRoot() {
@@ -164,12 +171,12 @@ public class Audrey implements Closeable {
         }
 
         public void enterRoot(final String rootNodeId) {
-            this.rootNodeId = rootNodeId;
+            rootNodeIds.push(rootNodeId);
             this.enteringRoot = true;
         }
 
         public void exitRoot() {
-            this.rootNodeId = "<Unknown>";
+            rootNodeIds.pop();
         }
 
         public void setEnteringRoot(final boolean flag) {

--- a/src/test/java/AudreyTest.java
+++ b/src/test/java/AudreyTest.java
@@ -337,7 +337,7 @@ public class AudreyTest {
 
         final Optional<Sample> innnerArgument = storage.newSearch()
             .forArguments()
-            .rootNodeId("makeOlder")
+            .rootNodeId("inner")
             .identifier("person")
             .findFirst();
 
@@ -345,14 +345,14 @@ public class AudreyTest {
 
         final Optional<Sample> innterReturn = storage.newSearch()
             .forReturns()
-            .rootNodeId("makeOlder")
+            .rootNodeId("inner")
             .findFirst();
 
         assertTrue(innterReturn.isPresent());
 
         final Optional<Sample> outerReturn = storage.newSearch()
             .forReturns()
-            .rootNodeId("init")
+            .rootNodeId("outer")
             .findFirst();
 
         assertTrue(outerReturn.isPresent());

--- a/src/test/java/AudreyTest.java
+++ b/src/test/java/AudreyTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -51,8 +52,8 @@ public class AudreyTest {
     }
 
     @Test
-    public void testSimpleEval() {
-        context.eval("js", "function foo(a) { console.log(a) } foo('bar')");
+    public void testSimpleEvalInJavaScript() {
+        evalFile("simple.js", "js");
 
         final Optional<Sample> arg = storage.newSearch()
             .forArguments()
@@ -62,6 +63,50 @@ public class AudreyTest {
 
         assertTrue(arg.isPresent());
         assertEquals("bar", arg.get().getValue());
+    }
+
+    @Test
+    public void testUnambiguousReturnsInJavaScript() {
+        evalFile("simple.js", "js");
+
+        final Stream<Sample> returns = storage.newSearch()
+            .forReturns()
+            .rootNodeId("foo")
+            .search();
+
+        assertEquals(1, returns.count());
+        final Optional<Sample> returnSample = returns.findFirst();
+        assertTrue(returnSample.isPresent());
+        assertEquals("42", returnSample.get().getValue());
+    }
+
+    @Test
+    public void testUnambiguousReturnsInRuby() {
+        evalFile("simple.rb", "ruby");
+
+        final Stream<Sample> returns = storage.newSearch()
+            .forReturns()
+            .rootNodeId("Object#foo")
+            .search();
+
+        assertEquals(1, returns.count());
+        final Optional<Sample> returnSample = returns.findFirst();
+        assertTrue(returnSample.isPresent());
+        assertEquals("42", returnSample.get().getValue());
+    }
+
+    @Test
+    public void testSimpleEvalInRuby() {
+        evalFile("simple.rb", "ruby");
+
+        final Optional<Sample> arg = storage.newSearch()
+            .forArguments()
+            .rootNodeId("Object#foo")
+            .identifier("a")
+            .findFirst();
+
+        assertTrue(arg.isPresent());
+        assertEquals("\"bar\"", arg.get().getValue());
     }
 
     @Test

--- a/src/test/java/AudreyTest.java
+++ b/src/test/java/AudreyTest.java
@@ -331,6 +331,26 @@ public class AudreyTest {
         assertTrue(ret2.isPresent());
     }
 
+    @Test
+    public void testNestedFunctionsInJavaScript() {
+        evalFile("nested_functions.js", "js");
+
+        final Optional<Sample> innnerArgument = storage.newSearch()
+            .forArguments()
+            .rootNodeId("makeOlder")
+            .identifier("person")
+            .findFirst();
+
+        assertTrue(innnerArgument.isPresent());
+
+        final Optional<Sample> innterReturn = storage.newSearch()
+            .forReturns()
+            .rootNodeId("makeOlder")
+            .findFirst();
+
+        assertTrue(innterReturn.isPresent());
+    }
+
     private Source makeSourceFromFile(String filename, String languageId) {
         return makeSource(readSourceString(filename), languageId);
     }

--- a/src/test/java/AudreyTest.java
+++ b/src/test/java/AudreyTest.java
@@ -74,10 +74,9 @@ public class AudreyTest {
             .rootNodeId("foo")
             .search();
 
-        assertEquals(1, returns.count());
-        final Optional<Sample> returnSample = returns.findFirst();
-        assertTrue(returnSample.isPresent());
-        assertEquals("42", returnSample.get().getValue());
+        final List<Sample> returnSamples = returns.collect(Collectors.toList());
+        assertEquals(1, returnSamples.size());
+        assertEquals("42", returnSamples.get(0).getValue());
     }
 
     @Test
@@ -89,10 +88,9 @@ public class AudreyTest {
             .rootNodeId("Object#foo")
             .search();
 
-        assertEquals(1, returns.count());
-        final Optional<Sample> returnSample = returns.findFirst();
-        assertTrue(returnSample.isPresent());
-        assertEquals("42", returnSample.get().getValue());
+        final List<Sample> returnSamples = returns.collect(Collectors.toList());
+        assertEquals(1, returnSamples.size());
+        assertEquals("42", returnSamples.get(0).getValue());
     }
 
     @Test

--- a/src/test/java/AudreyTest.java
+++ b/src/test/java/AudreyTest.java
@@ -52,7 +52,7 @@ public class AudreyTest {
     }
 
     @Test
-    public void testSimpleEvalInJavaScript() {
+    public void testSimpleEvalInJS() {
         evalFile("simple.js", "js");
 
         final Optional<Sample> arg = storage.newSearch()
@@ -66,7 +66,7 @@ public class AudreyTest {
     }
 
     @Test
-    public void testUnambiguousReturnsInJavaScript() {
+    public void testUnambiguousReturnsInJS() {
         evalFile("simple.js", "js");
 
         final Stream<Sample> returns = storage.newSearch()
@@ -108,7 +108,7 @@ public class AudreyTest {
     }
 
     @Test
-    public void testCollectsArgumentsAndReturnValuesInJavaScript() {
+    public void testCollectsArgumentsAndReturnValuesInJS() {
         evalFile("add.js", "js");
 
         final Optional<Sample> arg1 = storage.newSearch()
@@ -201,7 +201,7 @@ public class AudreyTest {
     }
 
     @Test
-    public void testCollectsNonPrimitiveValuesInJavaScript() {
+    public void testCollectsNonPrimitiveValuesInJS() {
         evalFile("non_primitive.js", "js");
 
         final Optional<Sample> arg = storage.newSearch()
@@ -245,7 +245,7 @@ public class AudreyTest {
     }
 
     @Test
-    public void testCanDifferentiateMethodsInJavascript() {
+    public void testCanDifferentiateMethodsInJS() {
         // NOTE that we currently extract arguments from the first statement in the function body.
         evalFile("two_greets.js", "js");
 
@@ -332,7 +332,7 @@ public class AudreyTest {
     }
 
     @Test
-    public void testNestedFunctionsInJavaScript() {
+    public void testNestedFunctionsInJS() {
         evalFile("nested_functions.js", "js");
 
         final Optional<Sample> innnerArgument = storage.newSearch()
@@ -349,6 +349,13 @@ public class AudreyTest {
             .findFirst();
 
         assertTrue(innterReturn.isPresent());
+
+        final Optional<Sample> outerReturn = storage.newSearch()
+            .forReturns()
+            .rootNodeId("init")
+            .findFirst();
+
+        assertTrue(outerReturn.isPresent());
     }
 
     private Source makeSourceFromFile(String filename, String languageId) {

--- a/src/test/test_sources/nested_functions.js
+++ b/src/test/test_sources/nested_functions.js
@@ -1,0 +1,12 @@
+function init() {
+    function makeOlder(person) {
+        person.age += 1;
+        return person;
+    }
+
+    const person = { name: 'boris', age: '17' };
+    makeOlder(person);
+    return person;
+}
+
+init();

--- a/src/test/test_sources/nested_functions.js
+++ b/src/test/test_sources/nested_functions.js
@@ -1,12 +1,12 @@
-function init() {
-    function makeOlder(person) {
+function outer() {
+    function inner(person) {
         person.age += 1;
         return person;
     }
 
     const person = { name: 'boris', age: '17' };
-    makeOlder(person);
+    inner(person);
     return person;
 }
 
-init();
+outer();

--- a/src/test/test_sources/simple.js
+++ b/src/test/test_sources/simple.js
@@ -1,0 +1,6 @@
+function foo(a) {
+    return 42;
+}
+
+foo('bar');
+1 + 1;

--- a/src/test/test_sources/simple.rb
+++ b/src/test/test_sources/simple.rb
@@ -1,0 +1,6 @@
+def foo(a)
+  42
+end
+
+foo "bar"
+1 + 1


### PR DESCRIPTION
Adresses https://trello.com/c/fARIIbdM.

I was not properly resetting the current root node during instrumentation.

We now push the current root node name onto a stack onEnter and pop it onReturn. The newly added tests describe broken use cases that are fixed with this approach.